### PR TITLE
Refactor datafetching

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -182,7 +182,7 @@ describe('App Component - Full User Interaction Flows', () => {
       // Should see validation error
       await waitFor(() => {
         expect(
-          screen.getByText(/please fill out all fields/i)
+          screen.getByText(/please fill out all required fields/i)
         ).toBeInTheDocument()
       })
 

--- a/src/components/molecules/LoreItem.tsx
+++ b/src/components/molecules/LoreItem.tsx
@@ -1,27 +1,20 @@
 import { Card, Typography, Flex, Divider, Popover } from 'antd'
-import { useQuery } from '@tanstack/react-query'
 import LoreMenu from '../organisms/LoreMenu'
 import type { Lore } from '../../types/data'
 import { InfoCircleOutlined } from '@ant-design/icons'
-import API from '../../api/API'
 
 const { Title, Text } = Typography
 
 interface LoreItemProps {
-  id?: string
+  lore?: Lore
 }
 
-export default function LoreItem({ id }: LoreItemProps) {
-  const { data } = useQuery<Lore>({
-    queryKey: ['lore', id],
-    queryFn: () => API.getLoreById(id!),
-    enabled: Boolean(id),
-  })
-  const { title, subtitle, game, createdAt, text } = data || {}
+export default function LoreItem({ lore }: LoreItemProps) {
+  const { title, subtitle, game, createdAt, text } = lore || {}
 
   return (
     <Card
-      loading={!data}
+      loading={!lore}
       style={{ width: 400, minHeight: 250 }}
       title={
         <Title
@@ -59,7 +52,7 @@ export default function LoreItem({ id }: LoreItemProps) {
           >
             <InfoCircleOutlined />
           </Popover>
-          <LoreMenu id={id} aria-label="Lore options" />
+          <LoreMenu lore={lore} aria-label="Lore options" />
         </Flex>
       }
     >

--- a/src/components/organisms/LoreMenu.test.tsx
+++ b/src/components/organisms/LoreMenu.test.tsx
@@ -9,10 +9,10 @@ import { mockLoreData } from '../../utils/testData'
 vi.mock('../../api/API')
 
 describe('LoreMenu', () => {
-  const mockId = '1'
+  const mockLore = mockLoreData[0]
 
   test('renders hamburger menu button', () => {
-    renderWithProviders(<LoreMenu id={mockId} />)
+    renderWithProviders(<LoreMenu lore={mockLore} />)
 
     const menuButton = screen.getByRole('button', { name: /options/i })
     expect(menuButton).toBeInTheDocument()
@@ -20,7 +20,7 @@ describe('LoreMenu', () => {
 
   test('opens menu when hamburger button is clicked', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<LoreMenu id={mockId} />)
+    renderWithProviders(<LoreMenu lore={mockLore} />)
 
     const menuButton = screen.getByRole('button', { name: /options/i })
     await user.click(menuButton)
@@ -32,7 +32,7 @@ describe('LoreMenu', () => {
 
   test('shows update and delete menu items when opened', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<LoreMenu id={mockId} />)
+    renderWithProviders(<LoreMenu lore={mockLore} />)
 
     const menuButton = screen.getByRole('button', { name: /options/i })
     await user.click(menuButton)
@@ -46,13 +46,13 @@ describe('LoreMenu', () => {
 
   test('passes correct id to menu items', async () => {
     const user = userEvent.setup()
-    const testId = '123'
+    const testLore = { ...mockLoreData[0], id: '123' }
     const mockDeleteLore = API.deleteLore as vi.MockedFunction<
       typeof API.deleteLore
     >
     mockDeleteLore.mockResolvedValue()
 
-    renderWithProviders(<LoreMenu id={testId} />)
+    renderWithProviders(<LoreMenu lore={testLore} />)
 
     // Open menu and delete
     const menuButton = screen.getByRole('button', { name: /options/i })
@@ -68,14 +68,14 @@ describe('LoreMenu', () => {
 
     // Should call API with correct ID
     await waitFor(() => {
-      expect(mockDeleteLore).toHaveBeenCalledWith(testId)
+      expect(mockDeleteLore).toHaveBeenCalledWith(testLore.id)
     })
   })
 
   describe('delete functionality', () => {
     test('opens delete alert dialog when delete is clicked', async () => {
       const user = userEvent.setup()
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       // Open menu
       const menuButton = screen.getByRole('button', { name: /options/i })
@@ -92,7 +92,7 @@ describe('LoreMenu', () => {
 
     test('closes menu after delete item is clicked', async () => {
       const user = userEvent.setup()
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       // Open menu
       const menuButton = screen.getByRole('button', { name: /options/i })
@@ -114,7 +114,7 @@ describe('LoreMenu', () => {
       >
       mockDeleteLore.mockResolvedValue()
 
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       // Open menu and click delete
       const menuButton = screen.getByRole('button', { name: /options/i })
@@ -131,7 +131,7 @@ describe('LoreMenu', () => {
 
       // API should be called
       await waitFor(() => {
-        expect(mockDeleteLore).toHaveBeenCalledWith(mockId)
+        expect(mockDeleteLore).toHaveBeenCalledWith(mockLore.id)
       })
 
       // Success message should appear
@@ -147,7 +147,7 @@ describe('LoreMenu', () => {
       >
       mockDeleteLore.mockResolvedValue()
 
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       // Open menu and click delete
       const menuButton = screen.getByRole('button', { name: /options/i })
@@ -178,7 +178,7 @@ describe('LoreMenu', () => {
       >
       mockDeleteLore.mockRejectedValue(new Error('Delete failed'))
 
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       // Open menu and click delete
       const menuButton = screen.getByRole('button', { name: /options/i })
@@ -208,7 +208,7 @@ describe('LoreMenu', () => {
       >
       mockGetLoreById.mockResolvedValue(mockLoreData[0])
 
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       // Open menu
       const menuButton = screen.getByRole('button', { name: /options/i })
@@ -226,7 +226,7 @@ describe('LoreMenu', () => {
 
     test('closes update modal when close is clicked', async () => {
       const user = userEvent.setup()
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       // Open menu and click update
       const menuButton = screen.getByRole('button', { name: /options/i })
@@ -258,7 +258,7 @@ describe('LoreMenu', () => {
       mockUpdateLore.mockRejectedValue(new Error('Update failed'))
 
       // Call the mutation directly to test error handling
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       const menuButton = screen.getByRole('button', { name: /options/i })
       await user.click(menuButton)
@@ -292,7 +292,7 @@ describe('LoreMenu', () => {
         updatedAt: new Date().toISOString(),
       })
 
-      renderWithProviders(<LoreMenu id={mockId} />)
+      renderWithProviders(<LoreMenu lore={mockLore} />)
 
       const menuButton = screen.getByRole('button', { name: /options/i })
       await user.click(menuButton)

--- a/src/components/organisms/LoreMenu.tsx
+++ b/src/components/organisms/LoreMenu.tsx
@@ -1,7 +1,7 @@
 import { MenuOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons'
 import { App, Dropdown, Button, type MenuProps } from 'antd'
 import { useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import API from '../../api/API'
 import type { Lore } from '../../types/data'
 import LoreFormModal from './LoreFormModal'
@@ -22,21 +22,18 @@ const items: MenuProps['items'] = [
 ]
 
 interface LoreMenuProps {
-  id?: string
+  lore?: Lore
 }
 
 /**
  * Hamburger menu on each LoreItem that gives
  * Update/Delete functionality
  */
-function LoreMenu({ id }: LoreMenuProps) {
+function LoreMenu({ lore }: LoreMenuProps) {
   const [updateModalOpen, setUpdateModalOpen] = useState(false)
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
   const { message } = App.useApp()
   const queryClient = useQueryClient()
-  const { data } = useQuery<Lore>({
-    queryKey: ['lore', id],
-  })
 
   // Update mutation
   const updateMutation = useMutation({
@@ -47,7 +44,7 @@ function LoreMenu({ id }: LoreMenuProps) {
     onSuccess: async () => {
       message.success('Lore updated!')
       await queryClient.invalidateQueries({
-        queryKey: ['lore', id],
+        queryKey: ['lore'],
       })
       setUpdateModalOpen(false)
     },
@@ -55,7 +52,7 @@ function LoreMenu({ id }: LoreMenuProps) {
 
   // Delete mutation
   const deleteMutation = useMutation({
-    mutationFn: () => API.deleteLore(id!),
+    mutationFn: () => API.deleteLore(String(lore?.id)),
     onError: (error) => {
       message.error(error.message)
     },
@@ -75,7 +72,7 @@ function LoreMenu({ id }: LoreMenuProps) {
     else setDeleteModalOpen(true)
   }
 
-  const existingData = buildInitialFormData(data)
+  const existingData = buildInitialFormData(lore)
 
   return (
     <>
@@ -83,8 +80,8 @@ function LoreMenu({ id }: LoreMenuProps) {
         <Button icon={<MenuOutlined />} type="text" aria-label="Options" />
       </Dropdown>
       <LoreFormModal
-        key={updateModalOpen ? id : 'closed'}
-        id={id}
+        key={updateModalOpen ? lore?.id : 'closed'}
+        id={lore?.id}
         initialFormData={existingData}
         mutation={updateMutation}
         isOpen={updateModalOpen}

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { Flex, Typography } from 'antd'
 import API from '../../api/API'
 import LoreItem from '../molecules/LoreItem'
@@ -6,10 +6,9 @@ import { type Lore } from '../../types/data'
 
 const { Text } = Typography
 
-type LoreOrPlaceholder = Pick<Lore, 'id'> | undefined
+type LoreOrPlaceholder = Lore | undefined
 
 export default function HomePage() {
-  const queryClient = useQueryClient()
   const {
     data = [],
     isFetched,
@@ -27,13 +26,6 @@ export default function HomePage() {
         return dateB - dateA
       })
 
-      /**
-       * Set each individual lore in query cache by id
-       */
-      sortedLore.forEach((element) =>
-        queryClient.setQueryData(['lore', element.id], element)
-      )
-
       return sortedLore
     },
   })
@@ -45,7 +37,7 @@ export default function HomePage() {
   // Create "fake" cards to render skeletons for while loading
   const loreData: LoreOrPlaceholder[] = !isFetched
     ? Array.from({ length: 20 }, () => undefined)
-    : data.map((lore) => ({ id: lore.id }))
+    : data
 
   return (
     <Flex gap={40} wrap justify="center">
@@ -53,7 +45,7 @@ export default function HomePage() {
         <Text>No lore entries found. Create the first one!</Text>
       )}
       {loreData.map((item, index) => {
-        return <LoreItem key={item?.id || index} id={item?.id} />
+        return <LoreItem key={item?.id || index} lore={item} />
       })}
     </Flex>
   )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
         branches: 77.4,
         functions: 100,
         lines: 99.56,
-        statements: 90.68,
+        statements: 89.66,
       },
     },
   },


### PR DESCRIPTION
# Summary

Please include a summary of changes

This pull request refactors how lore data is passed and managed between components, shifting from individual API queries for each lore item to passing complete lore objects as props. This change streamlines data flow, reduces redundant queries, and simplifies both the components and their tests. It also updates validation messaging for clarity.

**Lore Data Handling Refactor:**

* The `LoreItem` and `LoreMenu` components now receive a full `lore` object as a prop instead of just an `id`, eliminating the need for per-item API queries within these components. (`src/components/molecules/LoreItem.tsx`, `src/components/organisms/LoreMenu.tsx`) [[1]](diffhunk://#diff-e4496e6f914c48999051d7fe2b9209b0b1f164435f54b2f9a6ebf2ac3f28624aL2-R17) [[2]](diffhunk://#diff-a754494a5f2ccf370a7ec20158c13aba8ba38897add602b8387e391e082626e0L25-L39)
* The `HomePage` component now passes full lore objects to child components and removes logic that cached individual lore items by id, further simplifying data management. (`src/components/pages/HomePage.tsx`) [[1]](diffhunk://#diff-e2b6d675baa9863eb1e96b0328af8cb9df3410bdd74fd393f682db5a922e91f8L48-R48) [[2]](diffhunk://#diff-e2b6d675baa9863eb1e96b0328af8cb9df3410bdd74fd393f682db5a922e91f8L30-L36)

**Test Updates:**

* All relevant tests for `LoreMenu` have been updated to use lore objects instead of ids, ensuring consistency with the new data flow. (`src/components/organisms/LoreMenu.test.tsx`) [[1]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL12-R23) [[2]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL35-R35) [[3]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL49-R55) [[4]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL71-R78) [[5]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL95-R95) [[6]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL117-R117) [[7]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL134-R134) [[8]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL150-R150) [[9]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL181-R181) [[10]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL211-R211) [[11]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL229-R229) [[12]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL261-R261) [[13]](diffhunk://#diff-c032ca3403f3d2fa2750133fc3b4dc19674f912c1ef40d5c4e459e68797919ebL295-R295)

**API and Query Usage Simplification:**

* Removed unnecessary imports and internal usage of `useQuery` for fetching individual lore items in both `LoreItem` and `LoreMenu`, relying instead on props for all required data. (`src/components/molecules/LoreItem.tsx`, `src/components/organisms/LoreMenu.tsx`) [[1]](diffhunk://#diff-a754494a5f2ccf370a7ec20158c13aba8ba38897add602b8387e391e082626e0L4-R4) [[2]](diffhunk://#diff-a754494a5f2ccf370a7ec20158c13aba8ba38897add602b8387e391e082626e0L25-L39)
* Updated mutation and cache invalidation logic in `LoreMenu` to use a general `['lore']` query key, reflecting the new data structure. (`src/components/organisms/LoreMenu.tsx`)

**UI/UX Improvement:**

* The validation error message in the app is updated for clarity, now reading "please fill out all required fields." (`src/App.test.tsx`)

**Miscellaneous:**

* Minor update to code coverage thresholds in `vite.config.ts` to reflect the changes in statement coverage. (`vite.config.ts`)

## Type of change

Select all that apply (add an x inside brackets)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
